### PR TITLE
Enable storing checkpoints to remote file systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ great = GReaT.load_from_dir("my_directory")  # loads the model again
 
 # supports remote file systems via fsspec
 great.save("s3://my_bucket")
-great = GReaT.load_from_dir("my_directory")
+great = GReaT.load_from_dir("s3://my_bucket")
 ```
 
 ## GReaT Citation 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,16 @@ for clm in test_data.columns:
 imputed_data = model.impute(test_data, max_length=200)
 ```
 
+### Saving and Loading
+GReaT provides methods for saving a model checkpoint (besides the checkpoints stored by the huggingface transformers Trainer) and loading the checkpoint again.
+```python
+great.save("my_directory")  # saves a "model.pt" and a "config.json" file
+great = GReaT.load_from_dir("my_directory")  # loads the model again
 
+# supports remote file systems via fsspec
+great.save("s3://my_bucket")
+great = GReaT.load_from_dir("my_directory")
+```
 
 ## GReaT Citation 
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,14 @@ imputed_data = model.impute(test_data, max_length=200)
 ### Saving and Loading
 GReaT provides methods for saving a model checkpoint (besides the checkpoints stored by the huggingface transformers Trainer) and loading the checkpoint again.
 ```python
-great.save("my_directory")  # saves a "model.pt" and a "config.json" file
-great = GReaT.load_from_dir("my_directory")  # loads the model again
+model = GReaT(llm='distilgpt2', batch_size=32,  epochs=50, fp16=True)
+model.fit(data)
+model.save("my_directory")  # saves a "model.pt" and a "config.json" file
+model = GReaT.load_from_dir("my_directory")  # loads the model again
 
 # supports remote file systems via fsspec
-great.save("s3://my_bucket")
-great = GReaT.load_from_dir("s3://my_bucket")
+model.save("s3://my_bucket")
+model = GReaT.load_from_dir("s3://my_bucket")
 ```
 
 ## GReaT Citation 

--- a/be_great/great.py
+++ b/be_great/great.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 import json
 import typing as tp

--- a/be_great/great.py
+++ b/be_great/great.py
@@ -4,6 +4,7 @@ import json
 import typing as tp
 import logging
 
+import fsspec
 import numpy as np
 import pandas as pd
 
@@ -426,13 +427,14 @@ class GReaT:
             path: Path where to save the model
         """
         # Make directory
-        if os.path.isdir(path):
+        fs = fsspec.filesystem(fsspec.utils.get_protocol(path))
+        if fs.exists(path):
             warnings.warn(f"Directory {path} already exists and is overwritten now.")
         else:
-            os.mkdir(path)
+            fs.mkdir(path)
 
         # Save attributes
-        with open(path + "/config.json", "w") as f:
+        with fs.open(path + "/config.json", "w") as f:
             attributes = self.__dict__.copy()
             attributes.pop("tokenizer")
             attributes.pop("model")
@@ -446,7 +448,7 @@ class GReaT:
             json.dump(attributes, f)
 
         # Save model weights
-        torch.save(self.model.state_dict(), path + "/model.pt")
+        torch.save(self.model.state_dict(), fs.open(path + "/model.pt", "wb"))
 
     def load_finetuned_model(self, path: str):
         """Load fine-tuned model
@@ -456,7 +458,7 @@ class GReaT:
         Args:
             path: Path to the fine-tuned model
         """
-        self.model.load_state_dict(torch.load(path))
+        self.model.load_state_dict(torch.load(fsspec.open(path, "rb")))
 
     @classmethod
     def load_from_dir(cls, path: str):
@@ -470,10 +472,11 @@ class GReaT:
         Returns:
             New instance of GReaT loaded from directory
         """
-        assert os.path.isdir(path), f"Directory {path} does not exist."
+        fs = fsspec.filesystem(fsspec.utils.get_protocol(path))
+        assert fs.exists(path), f"Directory {path} does not exist."
 
         # Load attributes
-        with open(path + "/config.json", "r") as f:
+        with fs.open(path + "/config.json", "r") as f:
             attributes = json.load(f)
 
         # Create new be_great model instance
@@ -484,7 +487,7 @@ class GReaT:
             setattr(great, k, v)
 
         # Load model weights
-        great.model.load_state_dict(torch.load(path + "/model.pt", map_location="cpu"))
+        great.model.load_state_dict(torch.load(fs.open(path + "/model.pt", "rb"), map_location="cpu"))
 
         return great
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ torch >= 1.10.2
 tqdm >= 4.64.1
 transformers >= 4.22.1
 accelerate >= 0.20.1
+fsspec >= 2024.5.0


### PR DESCRIPTION
This change enables saving the model to a remote cloud storage (s3, azure, etc.) and loading it from there again.