### PR TITLE
PEFT import fixed

### DIFF
--- a/be_great/great.py
+++ b/be_great/great.py
@@ -87,7 +87,7 @@ class GReaT:
                 from peft import (
                     LoraConfig,
                     get_peft_model,
-                    prepare_model_for_int8_training,
+                    prepare_model_for_kbit_training,
                     TaskType,
                 )
             except ImportError:


### PR DESCRIPTION
When `efficient_finetuning` argument is set to `lora` when initializing the model, it generated an error when importing `prepare_model_for_int8_training`. So, I tried to change it to `prepare_model_for_kbit_training`.
<img width="507" alt="Screen Shot 2024-05-30 at 22 12 48" src="https://github.com/kathrinse/be_great/assets/48809651/d7c24593-74ec-47df-9b9d-385f26bf40e8">
