### PR TITLE
Fix compatibility issue: pin PEFT version to 0.9.0

### DIFF
--- a/be_great/great.py
+++ b/be_great/great.py
@@ -92,7 +92,7 @@ class GReaT:
                 )
             except ImportError:
                 raise ImportError(
-                    "This function requires the 'peft' package. Please install it with - pip install peft"
+                    "This function requires the 'peft' package. Please install it with - pip install peft==0.9.0"
                 )
 
             # Define LoRA Config


### PR DESCRIPTION
The function `prepare_model_for_int8_training` was removed in PEFT v0.10.0. To maintain compatibility with the codebase, I suggest to modify the comment instructing the users to install the pinned PEFT version, which is the last version that includes this function.

Relevant thread: https://github.com/huggingface/peft/issues/1583